### PR TITLE
chore: update Go installation method in build-pr workflow

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -37,9 +37,13 @@ on:
         description: 'Docker registry URL'
         required: true
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ${{ inputs.runs_on }}
+    permissions:
+      contents: read
     env:
       IMAGE_PREFIX: ${{ inputs.image_prefix }}
       AWS_XRAY_SDK_DISABLED: ${{ inputs.aws_xray_sdk_disabled }}
@@ -58,10 +62,12 @@ jobs:
         with:
           go-version: ${{ env.INSTALL_GO_VERSION }}
   
-      - uses: golangci/golangci-lint-action@v6
-        with:
-          version: ${{ env.GOLANGCI_LINT_VERSION }}
-      
+      - name: Install golangci-lint
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_LINT_VERSION}
+          mv $(go env GOPATH)/bin/golangci-lint /usr/local/bin/
+          golangci-lint --version
+
       - name: Lint and test
         run: |
           echo "Lint the sources..."

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -58,11 +58,9 @@ jobs:
         with:
           go-version: ${{ env.INSTALL_GO_VERSION }}
   
-      - name: Install golangci-lint
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $GOLANGCI_LINT_VERSION
-          mv $(go env GOPATH)/bin/golangci-lint /usr/local/bin/
-          golangci-lint --version
+      - uses: golangci/golangci-lint-action@v6
+        with:
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
       
       - name: Lint and test
         run: |

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -53,15 +53,14 @@ jobs:
         run: |
           echo "SRC=${GITHUB_WORKSPACE}/src" >> $GITHUB_ENV
           echo "TAG=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-      
-      - name: Install Go and tools
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.INSTALL_GO_VERSION }}
+  
+      - name: Install golangci-lint
         run: |
-          cd /root/.goenv && git pull && cd -
-          goenv install ${INSTALL_GO_VERSION} -s
-          goenv global ${INSTALL_GO_VERSION}
-          go version
-          
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_LINT_VERSION}
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $GOLANGCI_LINT_VERSION
           mv $(go env GOPATH)/bin/golangci-lint /usr/local/bin/
           golangci-lint --version
       


### PR DESCRIPTION
以下の改善をしました

- goenvでやっていた部分をsetup-goに置き換えました
- 最小権限のためワークフローレベルでは権限を空にし、ジョブレベルで権限を付与するようにしました

golangci-lintも公式アクションを使用しようと思いましたが、インストールではなくlintを目的としたものだったので採用を見送りました