### PR TITLE
add: trigger devin-pr-review at ready for review

### DIFF
--- a/.github/workflows/devin.yml
+++ b/.github/workflows/devin.yml
@@ -4,12 +4,13 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   devin-pr-review:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: |
       (github.event_name == 'pull_request' && !github.event.pull_request.draft)
     steps:

--- a/.github/workflows/devin.yml
+++ b/.github/workflows/devin.yml
@@ -2,7 +2,7 @@ name: "Devin PR Review"
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read


### PR DESCRIPTION
PRがドラフトの時はレビューしないようになっているので、PRがready_for_reviewになったとき、devinによるレビューを行うようにします。
また、同時に権限を絞ります。